### PR TITLE
Remove sizein option in cluster_otus call

### DIFF
--- a/wsl_distro_build/build-context/app/offline-analysis.pl
+++ b/wsl_distro_build/build-context/app/offline-analysis.pl
@@ -508,7 +508,7 @@ if ($doZ == 0) {
     #clusering of seq in OTUs (clustered)
     print ">>> Clustering ...";
     logToStatusFile("Cluster into OTUs...");
-    $command = $usearch . " -cluster_otus $pathout/$sorted_filename -otus $pathout/$otus_03_filename -relabel OTU_ -sizein";
+    $command = $usearch . " -cluster_otus $pathout/$sorted_filename -otus $pathout/$otus_03_filename -relabel OTU_";
     @output = `$command`;
     if ($?) {
         print "Clustering command failed\n";


### PR DESCRIPTION
Size annotations are required with a pipeline based on usearch11 and not optional as in usearch8. 
Size annotations are generated and attached by the fastx_uniques call in the dereplication step.